### PR TITLE
Implement client stdio

### DIFF
--- a/client/stdio.go
+++ b/client/stdio.go
@@ -1,0 +1,168 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// StdioServerParameters represents configuration for the stdio server
+type StdioServerParameters struct {
+	Command string            `json:"command"`     // The executable to run to start the server
+	Args    []string         `json:"args"`        // Command line arguments to pass to the executable
+	Env     map[string]string `json:"env"`         // The environment to use when spawning the process
+}
+
+// JSONRPCMessage represents a JSON-RPC message
+type JSONRPCMessage struct {
+	Method string          `json:"method,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	ID     interface{}     `json:"id,omitempty"`
+	Result interface{}     `json:"result,omitempty"`
+	Error  interface{}     `json:"error,omitempty"`
+}
+
+// MessageChan is a channel type for JSONRPCMessage
+type MessageChan chan JSONRPCMessage
+
+// StdioClient represents a client that communicates over stdio
+type StdioClient struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	stdout  io.ReadCloser
+	wg      sync.WaitGroup
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+// NewStdioClient creates a new stdio client with the given parameters
+func NewStdioClient(ctx context.Context, params StdioServerParameters) (*StdioClient, MessageChan, MessageChan, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(ctx, params.Command, params.Args...)
+	
+	if params.Env != nil {
+		cmd.Env = os.Environ() // Start with current environment
+		for k, v := range params.Env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, nil, nil, err
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		stdin.Close()
+		return nil, nil, nil, err
+	}
+
+	cmd.Stderr = os.Stderr
+
+	readChan := make(MessageChan)
+	writeChan := make(MessageChan)
+
+	client := &StdioClient{
+		cmd:     cmd,
+		stdin:   stdin,
+		stdout:  stdout,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		stdin.Close()
+		stdout.Close()
+		return nil, nil, nil, err
+	}
+
+	// Start goroutine for reading from stdout
+	client.wg.Add(1)
+	go func() {
+		defer client.wg.Done()
+		defer close(readChan)
+		
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				var message JSONRPCMessage
+				if err := json.Unmarshal(scanner.Bytes(), &message); err != nil {
+					continue
+				}
+				select {
+				case readChan <- message:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	// Start goroutine for writing to stdin
+	client.wg.Add(1)
+	go func() {
+		defer client.wg.Done()
+		defer close(writeChan)
+		defer stdin.Close()
+		
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case message, ok := <-writeChan:
+				if !ok {
+					return
+				}
+				data, err := json.Marshal(message)
+				if err != nil {
+					continue
+				}
+				data = append(data, '\n')
+				if _, err := stdin.Write(data); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	return client, readChan, writeChan, nil
+}
+
+// Close closes the stdio client and waits for all goroutines to finish
+func (c *StdioClient) Close() error {
+	// Cancel context first to stop goroutines
+	c.cancel()
+	
+	// Close stdin to signal EOF to the process
+	if err := c.stdin.Close(); err != nil {
+		return fmt.Errorf("failed to close stdin: %w", err)
+	}
+	
+	// Wait for goroutines to finish
+	c.wg.Wait()
+	
+	// Kill the process and wait for it to finish
+	c.cmd.Process.Kill()
+	
+	// Wait for the process to finish
+	if err := c.cmd.Wait(); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			return fmt.Errorf("failed to wait for process: %w", err)
+		}
+		// Ignore exit errors as we killed the process
+	}
+	
+	return nil
+}

--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -1,0 +1,219 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestStdioClient_Echo tests the stdio client with a simple echo server
+func TestStdioClient_Echo(t *testing.T) {
+	// Create a temporary echo script
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "echo.sh")
+	
+	script := `#!/bin/bash
+trap 'exit 0' SIGTERM SIGINT
+while IFS= read -r line; do
+    echo "$line"
+done
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create echo script: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	params := StdioServerParameters{
+		Command: "bash",
+		Args:    []string{scriptPath},
+	}
+
+	client, readChan, writeChan, err := NewStdioClient(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to create stdio client: %v", err)
+	}
+	
+	// Test message
+	testMsg := JSONRPCMessage{
+		Method: "test",
+		ID:     1,
+		Params: json.RawMessage(`{"hello":"world"}`),
+	}
+
+	// Send message
+	writeChan <- testMsg
+
+	// Read response with timeout
+	select {
+	case msg := <-readChan:
+		if msg.Method != testMsg.Method {
+			t.Errorf("Expected method %q, got %q", testMsg.Method, msg.Method)
+		}
+		// Compare ID values as float64 since JSON numbers are decoded as float64
+		expectedID := float64(testMsg.ID.(int))
+		actualID, ok := msg.ID.(float64)
+		if !ok {
+			t.Errorf("Expected ID to be float64, got %T", msg.ID)
+		} else if expectedID != actualID {
+			t.Errorf("Expected ID %v, got %v", expectedID, actualID)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for response")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Errorf("Failed to close client: %v", err)
+	}
+}
+
+// TestStdioClient_InvalidJSON tests handling of invalid JSON messages
+func TestStdioClient_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "invalid.sh")
+	
+	script := `#!/bin/bash
+trap 'exit 0' SIGTERM SIGINT
+echo "not a json message"
+echo '{"result": {"valid": "json"}}'
+sleep 0.1
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create script: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	params := StdioServerParameters{
+		Command: "bash",
+		Args:    []string{scriptPath},
+	}
+
+	client, readChan, _, err := NewStdioClient(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to create stdio client: %v", err)
+	}
+
+	// Should receive only the valid JSON message
+	select {
+	case msg := <-readChan:
+		if msg.Result == nil {
+			t.Errorf("Expected result not to be nil")
+			break
+		}
+		resultMap, ok := msg.Result.(map[string]interface{})
+		if !ok {
+			t.Errorf("Expected result to be a map, got %T", msg.Result)
+			break
+		}
+		if resultMap["valid"] != "json" {
+			t.Errorf("Expected valid json message, got %v", resultMap)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for response")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Errorf("Failed to close client: %v", err)
+	}
+}
+
+// TestStdioClient_Environment tests environment variable passing
+func TestStdioClient_Environment(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "env.sh")
+	
+	script := `#!/bin/bash
+trap 'exit 0' SIGTERM SIGINT
+echo '{"result": {"env": "'$TEST_ENV'"}}'
+sleep 0.1
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create script: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	params := StdioServerParameters{
+		Command: "bash",
+		Args:    []string{scriptPath},
+		Env:     map[string]string{"TEST_ENV": "test_value"},
+	}
+
+	client, readChan, _, err := NewStdioClient(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to create stdio client: %v", err)
+	}
+
+	select {
+	case msg := <-readChan:
+		if msg.Result == nil {
+			t.Errorf("Expected result not to be nil")
+			break
+		}
+		resultMap, ok := msg.Result.(map[string]interface{})
+		if !ok {
+			t.Errorf("Expected result to be a map, got %T", msg.Result)
+			break
+		}
+		if resultMap["env"] != "test_value" {
+			t.Errorf("Expected env value %q, got %q", "test_value", resultMap["env"])
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for response")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Errorf("Failed to close client: %v", err)
+	}
+}
+
+// TestStdioClient_Close tests proper cleanup
+func TestStdioClient_Close(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "long_running.sh")
+	
+	script := `#!/bin/bash
+trap 'exit 0' SIGTERM SIGINT
+while true; do
+    sleep 0.1
+done
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create script: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	params := StdioServerParameters{
+		Command: "bash",
+		Args:    []string{scriptPath},
+	}
+
+	client, _, _, err := NewStdioClient(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to create stdio client: %v", err)
+	}
+
+	// Close should not block indefinitely
+	done := make(chan error)
+	go func() {
+		done <- client.Close()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Close failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close timed out")
+	}
+}


### PR DESCRIPTION
# Add stdio-based JSON-RPC Client

This PR adds a new stdio-based JSON-RPC client implementation that enables communication with external processes via stdin/stdout pipes. Based on the python sdk implementation: https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/stdio.py