### PR TITLE
Remove empty checkbox from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ A maintainer will be happy to help you out.
 ### Tools
 - [x] Tool Calls
 - [x] Programatically generated tool list endpoint
-- [ ] 
 
 ### Prompts
 - [x] Prompt Calls


### PR DESCRIPTION
This commit removes a checkbox entry from the readme that was missing a description.