### PR TITLE
Implements handler update notifications

### DIFF
--- a/examples/basic_tool_server/basic_tool_server.go
+++ b/examples/basic_tool_server/basic_tool_server.go
@@ -26,7 +26,7 @@ func main() {
 		panic(err)
 	}
 
-	err = server.RegisterPrompt("promt_test", "This is a test prompt", func(arguments Content) (*mcp_golang.PromptResponse, error) {
+	err = server.RegisterPrompt("prompt_test", "This is a test prompt", func(arguments Content) (*mcp_golang.PromptResponse, error) {
 		return mcp_golang.NewPromptResponse("description", mcp_golang.NewPromptMessage(mcp_golang.NewTextContent(fmt.Sprintf("Hello, %server!", arguments.Title)), mcp_golang.RoleUser)), nil
 	})
 	if err != nil {

--- a/examples/basic_tool_server/basic_tool_server.go
+++ b/examples/basic_tool_server/basic_tool_server.go
@@ -20,7 +20,7 @@ func main() {
 
 	server := mcp_golang.NewServer(stdio.NewStdioServerTransport())
 	err := server.RegisterTool("hello", "Say hello to a person", func(arguments MyFunctionsArguments) (*mcp_golang.ToolResponse, error) {
-		return mcp_golang.NewToolReponse(mcp_golang.NewTextContent(fmt.Sprintf("Hello, %server!", arguments.Submitter))), nil
+		return mcp_golang.NewToolResponse(mcp_golang.NewTextContent(fmt.Sprintf("Hello, %server!", arguments.Submitter))), nil
 	})
 	if err != nil {
 		panic(err)

--- a/examples/get_weather_tool_server/get_weather_tool_server.go
+++ b/examples/get_weather_tool_server/get_weather_tool_server.go
@@ -28,7 +28,7 @@ func main() {
 		if err != nil {
 			return nil, err
 		}
-		return mcp_golang.NewToolReponse(mcp_golang.NewTextContent(string(output))), nil
+		return mcp_golang.NewToolResponse(mcp_golang.NewTextContent(string(output))), nil
 	})
 	err = server.Serve()
 	if err != nil {

--- a/examples/simple_tool_docs/simple_tool_docs.go
+++ b/examples/simple_tool_docs/simple_tool_docs.go
@@ -15,7 +15,7 @@ func main() {
 	done := make(chan struct{})
 	server := mcp_golang.NewServer(stdio.NewStdioServerTransport())
 	err := server.RegisterTool("hello", "Say hello to a person", func(arguments HelloArguments) (*mcp_golang.ToolResponse, error) {
-		return mcp_golang.NewToolReponse(mcp_golang.NewTextContent(fmt.Sprintf("Hello, %s!", arguments.Submitter))), nil
+		return mcp_golang.NewToolResponse(mcp_golang.NewTextContent(fmt.Sprintf("Hello, %s!", arguments.Submitter))), nil
 	})
 	err = server.Serve()
 	if err != nil {

--- a/examples/updating_registrations_on_the_fly/updating_registrations_on_the_fly.go
+++ b/examples/updating_registrations_on_the_fly/updating_registrations_on_the_fly.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	mcp_golang "github.com/metoro-io/mcp-golang"
+	"github.com/metoro-io/mcp-golang/transport/stdio"
+	"time"
+)
+
+type HelloArguments struct {
+	Submitter string `json:"submitter" jsonschema:"required,description=The name of the thing calling this tool (openai or google or claude etc)'"`
+}
+
+type Content struct {
+	Title       string  `json:"title" jsonschema:"required,description=The title to submit"`
+	Description *string `json:"description" jsonschema:"description=The description to submit"`
+}
+
+// This is a stupid server that demonstrates how to update registrations on the fly.
+// Every second the server will register a new tool, a new prompt and a new resource, then unregister the old ones.
+func main() {
+	done := make(chan struct{})
+	server := mcp_golang.NewServer(stdio.NewStdioServerTransport())
+	err := server.Serve()
+	if err != nil {
+		panic(err)
+	}
+	go func() {
+		for {
+			err := server.RegisterTool("hello", "Say hello to a person", func(arguments HelloArguments) (*mcp_golang.ToolResponse, error) {
+				return mcp_golang.NewToolResponse(mcp_golang.NewTextContent(fmt.Sprintf("Hello, %s!", arguments.Submitter))), nil
+			})
+			if err != nil {
+				panic(err)
+			}
+			time.Sleep(1 * time.Second)
+			err = server.DeregisterTool("hello")
+			if err != nil {
+				panic(err)
+			}
+		}
+	}()
+	go func() {
+		for {
+
+			err = server.RegisterPrompt("prompt_test", "This is a test prompt", func(arguments Content) (*mcp_golang.PromptResponse, error) {
+				return mcp_golang.NewPromptResponse("description", mcp_golang.NewPromptMessage(mcp_golang.NewTextContent(fmt.Sprintf("Hello, %server!", arguments.Title)), mcp_golang.RoleUser)), nil
+			})
+			if err != nil {
+				panic(err)
+			}
+			time.Sleep(1 * time.Second)
+			err = server.DeregisterPrompt("prompt_test")
+			if err != nil {
+				panic(err)
+			}
+		}
+
+	}()
+	go func() {
+		err = server.RegisterResource("test://resource", "resource_test", "This is a test resource", "application/json", func() (*mcp_golang.ResourceResponse, error) {
+			return mcp_golang.NewResourceResponse(mcp_golang.NewTextEmbeddedResource("test://resource", "This is a test resource", "application/json")), nil
+		})
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(1 * time.Second)
+		err = server.DeregisterResource("test://resource")
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	<-done
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -34,7 +34,7 @@ type EchoArgs struct {
 func main() {
 	server := mcp.NewServer(stdio.NewStdioServerTransport())
 	err := server.RegisterTool("echo", "Echo back the input message", func(args EchoArgs) (*mcp.ToolResponse, error) {
-		return mcp.NewToolReponse(mcp.NewTextContent(args.Message)), nil
+		return mcp.NewToolResponse(mcp.NewTextContent(args.Message)), nil
 	})
 	if err != nil {
 		panic(err)

--- a/internal/datastructures/generic_sync_map.go
+++ b/internal/datastructures/generic_sync_map.go
@@ -1,0 +1,35 @@
+package datastructures
+
+import "sync"
+
+type SyncMap[K comparable, V any] struct {
+	m sync.Map
+}
+
+func (m *SyncMap[K, V]) Delete(key K) {
+	m.m.Delete(key)
+}
+func (m *SyncMap[K, V]) Load(key K) (value V, ok bool) {
+	v, ok := m.m.Load(key)
+	if !ok {
+		return value, ok
+	}
+	return v.(V), ok
+}
+func (m *SyncMap[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
+	v, loaded := m.m.LoadAndDelete(key)
+	if !loaded {
+		return value, loaded
+	}
+	return v.(V), loaded
+}
+func (m *SyncMap[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	a, loaded := m.m.LoadOrStore(key, value)
+	return a.(V), loaded
+}
+func (m *SyncMap[K, V]) Range(f func(key K, value V) bool) {
+	m.m.Range(func(key, value any) bool { return f(key.(K), value.(V)) })
+}
+func (m *SyncMap[K, V]) Store(key K, value V) {
+	m.m.Store(key, value)
+}

--- a/internal/testingutils/mock_transport.go
+++ b/internal/testingutils/mock_transport.go
@@ -1,4 +1,4 @@
-package protocol
+package testingutils
 
 import (
 	"context"
@@ -6,8 +6,8 @@ import (
 	"sync"
 )
 
-// mockTransport implements Transport interface for testing
-type mockTransport struct {
+// MockTransport implements Transport interface for testing
+type MockTransport struct {
 	mu sync.RWMutex
 
 	// Callbacks
@@ -21,27 +21,27 @@ type mockTransport struct {
 	started  bool
 }
 
-func newMockTransport() *mockTransport {
-	return &mockTransport{
+func NewMockTransport() *MockTransport {
+	return &MockTransport{
 		messages: make([]*transport.BaseJsonRpcMessage, 0),
 	}
 }
 
-func (t *mockTransport) Start(ctx context.Context) error {
+func (t *MockTransport) Start(ctx context.Context) error {
 	t.mu.Lock()
 	t.started = true
 	t.mu.Unlock()
 	return nil
 }
 
-func (t *mockTransport) Send(message *transport.BaseJsonRpcMessage) error {
+func (t *MockTransport) Send(message *transport.BaseJsonRpcMessage) error {
 	t.mu.Lock()
 	t.messages = append(t.messages, message)
 	t.mu.Unlock()
 	return nil
 }
 
-func (t *mockTransport) Close() error {
+func (t *MockTransport) Close() error {
 	t.mu.Lock()
 	t.closed = true
 	t.mu.Unlock()
@@ -51,19 +51,19 @@ func (t *mockTransport) Close() error {
 	return nil
 }
 
-func (t *mockTransport) SetCloseHandler(handler func()) {
+func (t *MockTransport) SetCloseHandler(handler func()) {
 	t.mu.Lock()
 	t.onClose = handler
 	t.mu.Unlock()
 }
 
-func (t *mockTransport) SetErrorHandler(handler func(error)) {
+func (t *MockTransport) SetErrorHandler(handler func(error)) {
 	t.mu.Lock()
 	t.onError = handler
 	t.mu.Unlock()
 }
 
-func (t *mockTransport) SetMessageHandler(handler func(*transport.BaseJsonRpcMessage)) {
+func (t *MockTransport) SetMessageHandler(handler func(*transport.BaseJsonRpcMessage)) {
 	t.mu.Lock()
 	t.onMessage = handler
 	t.mu.Unlock()
@@ -71,7 +71,7 @@ func (t *mockTransport) SetMessageHandler(handler func(*transport.BaseJsonRpcMes
 
 // Test helper methods
 
-func (t *mockTransport) simulateMessage(msg *transport.BaseJsonRpcMessage) {
+func (t *MockTransport) SimulateMessage(msg *transport.BaseJsonRpcMessage) {
 	t.mu.RLock()
 	handler := t.onMessage
 	t.mu.RUnlock()
@@ -80,7 +80,7 @@ func (t *mockTransport) simulateMessage(msg *transport.BaseJsonRpcMessage) {
 	}
 }
 
-func (t *mockTransport) simulateError(err error) {
+func (t *MockTransport) SimulateError(err error) {
 	t.mu.RLock()
 	handler := t.onError
 	t.mu.RUnlock()
@@ -89,7 +89,7 @@ func (t *mockTransport) simulateError(err error) {
 	}
 }
 
-func (t *mockTransport) getMessages() []*transport.BaseJsonRpcMessage {
+func (t *MockTransport) GetMessages() []*transport.BaseJsonRpcMessage {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	msgs := make([]*transport.BaseJsonRpcMessage, len(t.messages))
@@ -97,13 +97,13 @@ func (t *mockTransport) getMessages() []*transport.BaseJsonRpcMessage {
 	return msgs
 }
 
-func (t *mockTransport) isClosed() bool {
+func (t *MockTransport) IsClosed() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.closed
 }
 
-func (t *mockTransport) isStarted() bool {
+func (t *MockTransport) IsStarted() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.started

--- a/server.go
+++ b/server.go
@@ -498,7 +498,7 @@ func (s *Server) handleListTools(_ *transport.BaseJSONRPCRequest, _ protocol.Req
 	//println("listing tools")
 	return tools.ToolsResponse{
 		Tools: func() []tools.ToolRetType {
-			var ts []tools.ToolRetType
+			var ts = make([]tools.ToolRetType, 0)
 			s.tools.Range(func(k string, t *tool) bool {
 				ts = append(ts, tools.ToolRetType{
 					Name:        t.Name,
@@ -552,7 +552,7 @@ func (s *Server) generateCapabilities() serverCapabilities {
 func (s *Server) handleListPrompts(request *transport.BaseJSONRPCRequest, extra protocol.RequestHandlerExtra) (transport.JsonRpcBody, error) {
 	return listPromptsResult{
 		Prompts: func() []*promptSchema {
-			var prompts []*promptSchema
+			var prompts = make([]*promptSchema, 0)
 			s.prompts.Range(func(k string, p *prompt) bool {
 				prompts = append(prompts, p.PromptInputSchema)
 				return true
@@ -565,7 +565,7 @@ func (s *Server) handleListPrompts(request *transport.BaseJSONRPCRequest, extra 
 func (s *Server) handleListResources(request *transport.BaseJSONRPCRequest, extra protocol.RequestHandlerExtra) (transport.JsonRpcBody, error) {
 	return listResourcesResult{
 		Resources: func() []*resourceSchema {
-			var resources []*resourceSchema
+			var resources = make([]*resourceSchema, 0)
 			s.resources.Range(func(k string, r *resource) bool {
 				resources = append(resources, &resourceSchema{
 					Annotations: nil,

--- a/server.go
+++ b/server.go
@@ -3,8 +3,10 @@ package mcp_golang
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/metoro-io/mcp-golang/internal/datastructures"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/invopop/jsonschema"
 	"github.com/metoro-io/mcp-golang/internal/protocol"
@@ -96,10 +98,13 @@ func (c promptResponseSent) MarshalJSON() ([]byte, error) {
 }
 
 type Server struct {
+	isRunning          bool
+	mutex              sync.Mutex
 	transport          transport.Transport
-	tools              map[string]*tool
-	prompts            map[string]*prompt
-	resources          map[string]*resource
+	protocol           *protocol.Protocol
+	tools              *datastructures.SyncMap[string, *tool]
+	prompts            *datastructures.SyncMap[string, *prompt]
+	resources          *datastructures.SyncMap[string, *resource]
 	serverInstructions *string
 	serverName         string
 	serverVersion      string
@@ -130,9 +135,9 @@ type resource struct {
 func NewServer(transport transport.Transport) *Server {
 	return &Server{
 		transport: transport,
-		tools:     make(map[string]*tool),
-		prompts:   make(map[string]*prompt),
-		resources: make(map[string]*resource),
+		tools:     new(datastructures.SyncMap[string, *tool]),
+		prompts:   new(datastructures.SyncMap[string, *prompt]),
+		resources: new(datastructures.SyncMap[string, *resource]),
 	}
 }
 
@@ -144,14 +149,31 @@ func (s *Server) RegisterTool(name string, description string, handler any) erro
 	}
 	inputSchema := createJsonSchemaFromHandler(handler)
 
-	s.tools[name] = &tool{
+	s.tools.Store(name, &tool{
 		Name:            name,
 		Description:     description,
 		Handler:         createWrappedToolHandler(handler),
 		ToolInputSchema: inputSchema,
-	}
+	})
 
 	return nil
+}
+
+func (s *Server) sendToolListChangedNotification() error {
+	if !s.isRunning {
+		return nil
+	}
+	return s.protocol.Notification("notifications/tools/list_changed", nil)
+}
+
+func (s *Server) CheckToolRegistered(name string) bool {
+	_, ok := s.tools.Load(name)
+	return ok
+}
+
+func (s *Server) DeregisterTool(name string) error {
+	s.tools.Delete(name)
+	return s.sendToolListChangedNotification()
 }
 
 func (s *Server) RegisterResource(uri string, name string, description string, mimeType string, handler any) error {
@@ -159,14 +181,31 @@ func (s *Server) RegisterResource(uri string, name string, description string, m
 	if err != nil {
 		panic(err)
 	}
-	s.resources[uri] = &resource{
+	s.resources.Store(uri, &resource{
 		Name:        name,
 		Description: description,
 		Uri:         uri,
 		mimeType:    mimeType,
 		Handler:     createWrappedResourceHandler(handler),
+	})
+	return s.sendResourceListChangedNotification()
+}
+
+func (s *Server) sendResourceListChangedNotification() error {
+	if !s.isRunning {
+		return nil
 	}
-	return nil
+	return s.protocol.Notification("notifications/resources/list_changed", nil)
+}
+
+func (s *Server) CheckResourceRegistered(uri string) bool {
+	_, ok := s.resources.Load(uri)
+	return ok
+}
+
+func (s *Server) DeregisterResource(uri string) error {
+	s.resources.Delete(uri)
+	return s.sendResourceListChangedNotification()
 }
 
 func createWrappedResourceHandler(userHandler any) func() *resourceResponseSent {
@@ -219,14 +258,31 @@ func (s *Server) RegisterPrompt(name string, description string, handler any) er
 		return err
 	}
 	promptSchema := createPromptSchemaFromHandler(handler)
-	s.prompts[name] = &prompt{
+	s.prompts.Store(name, &prompt{
 		Name:              name,
 		Description:       description,
 		Handler:           createWrappedPromptHandler(handler),
 		PromptInputSchema: promptSchema,
-	}
+	})
 
-	return nil
+	return s.sendPromptListChangedNotification()
+}
+
+func (s *Server) sendPromptListChangedNotification() error {
+	if !s.isRunning {
+		return nil
+	}
+	return s.protocol.Notification("notifications/prompts/list_changed", nil)
+}
+
+func (s *Server) CheckPromptRegistered(name string) bool {
+	_, ok := s.prompts.Load(name)
+	return ok
+}
+
+func (s *Server) DeregisterPrompt(name string) error {
+	s.prompts.Delete(name)
+	return s.sendPromptListChangedNotification()
 }
 
 func createWrappedPromptHandler(userHandler any) func(baseGetPromptRequestParamsArguments) *promptResponseSent {
@@ -399,7 +455,11 @@ func createWrappedToolHandler(userHandler any) func(baseCallToolRequestParams) *
 }
 
 func (s *Server) Serve() error {
+	if s.isRunning == true {
+		return fmt.Errorf("server is already running")
+	}
 	pr := protocol.NewProtocol(nil)
+	pr.SetRequestHandler("ping", s.handlePing)
 	pr.SetRequestHandler("initialize", s.handleInitialize)
 	pr.SetRequestHandler("tools/list", s.handleListTools)
 	pr.SetRequestHandler("tools/call", s.handleToolCalls)
@@ -407,7 +467,13 @@ func (s *Server) Serve() error {
 	pr.SetRequestHandler("prompts/get", s.handlePromptCalls)
 	pr.SetRequestHandler("resources/list", s.handleListResources)
 	pr.SetRequestHandler("resources/read", s.handleResourceCalls)
-	return pr.Connect(s.transport)
+	err := pr.Connect(s.transport)
+	if err != nil {
+		return err
+	}
+	s.protocol = pr
+	s.isRunning = true
+	return nil
 }
 
 func (s *Server) handleInitialize(_ *transport.BaseJSONRPCRequest, _ protocol.RequestHandlerExtra) (transport.JsonRpcBody, error) {
@@ -428,13 +494,14 @@ func (s *Server) handleListTools(_ *transport.BaseJSONRPCRequest, _ protocol.Req
 	return tools.ToolsResponse{
 		Tools: func() []tools.ToolRetType {
 			var ts []tools.ToolRetType
-			for _, tool := range s.tools {
+			s.tools.Range(func(k string, t *tool) bool {
 				ts = append(ts, tools.ToolRetType{
-					Name:        tool.Name,
-					Description: &tool.Description,
-					InputSchema: tool.ToolInputSchema,
+					Name:        t.Name,
+					Description: &t.Description,
+					InputSchema: t.ToolInputSchema,
 				})
-			}
+				return true
+			})
 			return ts
 		}(),
 	}, nil
@@ -448,13 +515,19 @@ func (s *Server) handleToolCalls(req *transport.BaseJSONRPCRequest, _ protocol.R
 		return nil, fmt.Errorf("failed to unmarshal arguments: %w", err)
 	}
 
-	for name, tool := range s.tools {
-		if name != params.Name {
-			continue
+	var toolToUse *tool
+	s.tools.Range(func(k string, t *tool) bool {
+		if k != params.Name {
+			return true
 		}
-		return tool.Handler(params), nil
+		toolToUse = t
+		return false
+	})
+
+	if toolToUse == nil {
+		return nil, fmt.Errorf("unknown tool: %s", req.Method)
 	}
-	return nil, fmt.Errorf("unknown tool: %s", req.Method)
+	return toolToUse.Handler(params), nil
 }
 
 func (s *Server) generateCapabilities() serverCapabilities {
@@ -475,9 +548,10 @@ func (s *Server) handleListPrompts(request *transport.BaseJSONRPCRequest, extra 
 	return listPromptsResult{
 		Prompts: func() []*promptSchema {
 			var prompts []*promptSchema
-			for _, prompt := range s.prompts {
-				prompts = append(prompts, prompt.PromptInputSchema)
-			}
+			s.prompts.Range(func(k string, p *prompt) bool {
+				prompts = append(prompts, p.PromptInputSchema)
+				return true
+			})
 			return prompts
 		}(),
 	}, nil
@@ -487,15 +561,16 @@ func (s *Server) handleListResources(request *transport.BaseJSONRPCRequest, extr
 	return listResourcesResult{
 		Resources: func() []*resourceSchema {
 			var resources []*resourceSchema
-			for _, resource := range s.resources {
+			s.resources.Range(func(k string, r *resource) bool {
 				resources = append(resources, &resourceSchema{
 					Annotations: nil,
-					Description: &resource.Description,
-					MimeType:    &resource.mimeType,
-					Name:        resource.Name,
-					Uri:         resource.Uri,
+					Description: &r.Description,
+					MimeType:    &r.mimeType,
+					Name:        r.Name,
+					Uri:         r.Uri,
 				})
-			}
+				return true
+			})
 			return resources
 		}(),
 	}, nil
@@ -509,13 +584,19 @@ func (s *Server) handlePromptCalls(req *transport.BaseJSONRPCRequest, extra prot
 		return nil, fmt.Errorf("failed to unmarshal arguments: %w", err)
 	}
 
-	for name, prompter := range s.prompts {
-		if name != params.Name {
-			continue
+	var promptToUse *prompt
+	s.prompts.Range(func(k string, p *prompt) bool {
+		if k != params.Name {
+			return true
 		}
-		return prompter.Handler(params), nil
+		promptToUse = p
+		return false
+	})
+
+	if promptToUse == nil {
+		return nil, fmt.Errorf("unknown prompt: %s", req.Method)
 	}
-	return nil, fmt.Errorf("unknown prompt: %s", req.Method)
+	return promptToUse.Handler(params), nil
 }
 
 func (s *Server) handleResourceCalls(req *transport.BaseJSONRPCRequest, extra protocol.RequestHandlerExtra) (transport.JsonRpcBody, error) {
@@ -526,13 +607,23 @@ func (s *Server) handleResourceCalls(req *transport.BaseJSONRPCRequest, extra pr
 		return nil, fmt.Errorf("failed to unmarshal arguments: %w", err)
 	}
 
-	for name, resource := range s.resources {
-		if name != params.Uri {
-			continue
+	var resourceToUse *resource
+	s.resources.Range(func(k string, r *resource) bool {
+		if k != params.Uri {
+			return true
 		}
-		return resource.Handler(), nil
+		resourceToUse = r
+		return false
+	})
+
+	if resourceToUse == nil {
+		return nil, fmt.Errorf("unknown prompt: %s", req.Method)
 	}
-	return nil, fmt.Errorf("unknown prompt: %s", req.Method)
+	return resourceToUse.Handler(), nil
+}
+
+func (s *Server) handlePing(request *transport.BaseJSONRPCRequest, extra protocol.RequestHandlerExtra) (transport.JsonRpcBody, error) {
+	return map[string]interface{}{}, nil
 }
 
 func validateToolHandler(handler any) error {

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,153 @@
+package mcp_golang
+
+import (
+	"github.com/metoro-io/mcp-golang/internal/testingutils"
+	"testing"
+)
+
+func TestServerListChangedNotifications(t *testing.T) {
+	mockTransport := testingutils.NewMockTransport()
+	server := NewServer(mockTransport)
+	err := server.Serve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test tool registration notification
+	type TestToolArgs struct {
+		Message string `json:"message" jsonschema:"required,description=A test message"`
+	}
+	err = server.RegisterTool("test-tool", "Test tool", func(args TestToolArgs) (*ToolResponse, error) {
+		return NewToolResponse(), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages := mockTransport.GetMessages()
+	if len(messages) != 1 {
+		t.Fatalf("Expected 1 message after tool registration, got %d", len(messages))
+	}
+	if messages[0].JsonRpcNotification.Method != "notifications/tools/list_changed" {
+		t.Errorf("Expected tools list changed notification, got %s", messages[0].JsonRpcNotification.Method)
+	}
+
+	// Test tool deregistration notification
+	mockTransport = testingutils.NewMockTransport()
+	server = NewServer(mockTransport)
+	err = server.Serve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.RegisterTool("test-tool", "Test tool", func(args TestToolArgs) (*ToolResponse, error) {
+		return NewToolResponse(), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.DeregisterTool("test-tool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages = mockTransport.GetMessages()
+	if len(messages) != 2 {
+		t.Fatalf("Expected 2 messages after tool registration and deregistration, got %d", len(messages))
+	}
+	if messages[1].JsonRpcNotification.Method != "notifications/tools/list_changed" {
+		t.Errorf("Expected tools list changed notification, got %s", messages[1].JsonRpcNotification.Method)
+	}
+
+	// Test prompt registration notification
+	type TestPromptArgs struct {
+		Query string `json:"query" jsonschema:"required,description=A test query"`
+	}
+	mockTransport = testingutils.NewMockTransport()
+	server = NewServer(mockTransport)
+	err = server.Serve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.RegisterPrompt("test-prompt", "Test prompt", func(args TestPromptArgs) (*PromptResponse, error) {
+		return NewPromptResponse("test", NewPromptMessage(NewTextContent("test"), RoleUser)), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages = mockTransport.GetMessages()
+	if len(messages) != 1 {
+		t.Fatalf("Expected 1 message after prompt registration, got %d", len(messages))
+	}
+	if messages[0].JsonRpcNotification.Method != "notifications/prompts/list_changed" {
+		t.Errorf("Expected prompts list changed notification, got %s", messages[0].JsonRpcNotification.Method)
+	}
+
+	// Test prompt deregistration notification
+	mockTransport = testingutils.NewMockTransport()
+	server = NewServer(mockTransport)
+	err = server.Serve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.RegisterPrompt("test-prompt", "Test prompt", func(args TestPromptArgs) (*PromptResponse, error) {
+		return NewPromptResponse("test", NewPromptMessage(NewTextContent("test"), RoleUser)), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.DeregisterPrompt("test-prompt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages = mockTransport.GetMessages()
+	if len(messages) != 2 {
+		t.Fatalf("Expected 2 messages after prompt registration and deregistration, got %d", len(messages))
+	}
+	if messages[1].JsonRpcNotification.Method != "notifications/prompts/list_changed" {
+		t.Errorf("Expected prompts list changed notification, got %s", messages[1].JsonRpcNotification.Method)
+	}
+
+	// Test resource registration notification
+	mockTransport = testingutils.NewMockTransport()
+	server = NewServer(mockTransport)
+	err = server.Serve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.RegisterResource("test://resource", "test-resource", "Test resource", "text/plain", func() (*ResourceResponse, error) {
+		return NewResourceResponse(NewTextEmbeddedResource("test://resource", "test content", "text/plain")), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages = mockTransport.GetMessages()
+	if len(messages) != 1 {
+		t.Fatalf("Expected 1 message after resource registration, got %d", len(messages))
+	}
+	if messages[0].JsonRpcNotification.Method != "notifications/resources/list_changed" {
+		t.Errorf("Expected resources list changed notification, got %s", messages[0].JsonRpcNotification.Method)
+	}
+
+	// Test resource deregistration notification
+	mockTransport = testingutils.NewMockTransport()
+	server = NewServer(mockTransport)
+	err = server.Serve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.RegisterResource("test://resource", "test-resource", "Test resource", "text/plain", func() (*ResourceResponse, error) {
+		return NewResourceResponse(NewTextEmbeddedResource("test://resource", "test content", "text/plain")), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.DeregisterResource("test://resource")
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages = mockTransport.GetMessages()
+	if len(messages) != 2 {
+		t.Fatalf("Expected 2 messages after resource registration and deregistration, got %d", len(messages))
+	}
+	if messages[1].JsonRpcNotification.Method != "notifications/resources/list_changed" {
+		t.Errorf("Expected resources list changed notification, got %s", messages[1].JsonRpcNotification.Method)
+	}
+}

--- a/tool_api.go
+++ b/tool_api.go
@@ -6,7 +6,7 @@ type ToolResponse struct {
 	Content []*Content
 }
 
-func NewToolReponse(content ...*Content) *ToolResponse {
+func NewToolResponse(content ...*Content) *ToolResponse {
 	return &ToolResponse{
 		Content: content,
 	}


### PR DESCRIPTION
Closes #19 #20 #22 

Implements the optional list changed notifications for tools, resources and prompts.

This updates clients whenever the handlers for the server are updated. Prompting them to list again.

https://spec.modelcontextprotocol.io/specification/server/resources/#list-changed-notification