### PR TITLE
[#63] Fix HTTP transport by removing duplication of base transport

### DIFF
--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -5,22 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sync"
-
-	"github.com/metoro-io/mcp-golang/transport"
 )
 
 // HTTPTransport implements a stateless HTTP transport for MCP
 type HTTPTransport struct {
 	*baseTransport
-	server         *http.Server
-	endpoint       string
-	messageHandler func(ctx context.Context, message *transport.BaseJsonRpcMessage)
-	errorHandler   func(error)
-	closeHandler   func()
-	mu             sync.RWMutex
-	addr           string
-	responseMap    map[int64]chan *transport.BaseJsonRpcMessage
+	server   *http.Server
+	endpoint string
+	addr     string
 }
 
 // NewHTTPTransport creates a new HTTP transport that listens on the specified endpoint
@@ -29,7 +21,6 @@ func NewHTTPTransport(endpoint string) *HTTPTransport {
 		baseTransport: newBaseTransport(),
 		endpoint:      endpoint,
 		addr:          ":8080", // Default port
-		responseMap:   make(map[int64]chan *transport.BaseJsonRpcMessage),
 	}
 }
 
@@ -52,17 +43,6 @@ func (t *HTTPTransport) Start(ctx context.Context) error {
 	return t.server.ListenAndServe()
 }
 
-// Send implements Transport.Send
-func (t *HTTPTransport) Send(ctx context.Context, message *transport.BaseJsonRpcMessage) error {
-	key := message.JsonRpcResponse.Id
-	responseChannel := t.responseMap[int64(key)]
-	if responseChannel == nil {
-		return fmt.Errorf("no response channel found for key: %d", key)
-	}
-	responseChannel <- message
-	return nil
-}
-
 // Close implements Transport.Close
 func (t *HTTPTransport) Close() error {
 	if t.server != nil {
@@ -70,31 +50,8 @@ func (t *HTTPTransport) Close() error {
 			return err
 		}
 	}
-	if t.closeHandler != nil {
-		t.closeHandler()
-	}
-	return nil
-}
 
-// SetCloseHandler implements Transport.SetCloseHandler
-func (t *HTTPTransport) SetCloseHandler(handler func()) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.closeHandler = handler
-}
-
-// SetErrorHandler implements Transport.SetErrorHandler
-func (t *HTTPTransport) SetErrorHandler(handler func(error)) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.errorHandler = handler
-}
-
-// SetMessageHandler implements Transport.SetMessageHandler
-func (t *HTTPTransport) SetMessageHandler(handler func(ctx context.Context, message *transport.BaseJsonRpcMessage)) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.messageHandler = handler
+	return t.baseTransport.Close()
 }
 
 func (t *HTTPTransport) handleRequest(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Issue
https://github.com/metoro-io/mcp-golang/issues/63

## Explanation of bug
The [`http.HTTPTransport`](https://github.com/metoro-io/mcp-golang/blob/219a9729ed499e5b93b65160c496733acc23e137/transport/http/http.go#L14-L24) duplicated much of the [`http.baseTransport`'s](https://github.com/metoro-io/mcp-golang/blob/219a9729ed499e5b93b65160c496733acc23e137/transport/http/common.go#L14-L20`) fields and methods.

This resulted in a deadlock caused by a [non-nil channel](https://github.com/metoro-io/mcp-golang/blob/219a9729ed499e5b93b65160c496733acc23e137/transport/http/common.go#L80) being [waited on for a receive](https://github.com/metoro-io/mcp-golang/blob/219a9729ed499e5b93b65160c496733acc23e137/transport/http/common.go#L147) and never receiving anything because we have a [nil handler](https://github.com/metoro-io/mcp-golang/blob/219a9729ed499e5b93b65160c496733acc23e137/transport/http/common.go#L93-L98). The handler is nil because the [protocol is setting the message handler](https://github.com/metoro-io/mcp-golang/blob/219a9729ed499e5b93b65160c496733acc23e137/internal/protocol/protocol.go#L178-L189) using [`http.HTTPTransport.SetMessageHandler()`](https://github.com/metoro-io/mcp-golang/blob/219a9729ed499e5b93b65160c496733acc23e137/transport/http/http.go#L94-L98), which did not have the same outcome as [`http.HTTPTransport.baseTransport.SetMessageHandler()`](https://github.com/metoro-io/mcp-golang/blob/219a9729ed499e5b93b65160c496733acc23e137/transport/http/common.go#L62-L66), due to the duplicated fields and methods in the two structs.

## Solution
Removed the duplication of `http.baseTransport` fields and methods from the `http.HTTPTransport`.

I can now start up the server, locally, and observe the following:
```
% curl -v -X POST http://localhost:8080/mcp \
  -H "Content-Type: application/json" \
  -d '{
    "jsonrpc": "2.0",
    "method": "initialize",
    "id": 1,
    "params": {}
  }'
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> POST /mcp HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 85
> 
* upload completely sent off: 85 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Mon, 27 Jan 2025 18:44:19 GMT
< Content-Length: 217
< 
* Connection #0 to host localhost left intact
{"id":1,"jsonrpc":"2.0","result":{"capabilities":{"prompts":{"listChanged":false},"resources":{"listChanged":false},"tools":{"listChanged":false}},"protocolVersion":"2024-11-05","serverInfo":{"name":"","version":""}}}% 
```

Prior to the changes, this would have hung indefinitely (deadlock).