### PR TITLE
[#67] Fix Client's ReadResource method

### DIFF
--- a/client.go
+++ b/client.go
@@ -235,17 +235,13 @@ func (c *Client) ReadResource(ctx context.Context, uri string) (*ResourceRespons
 		return nil, errors.New("invalid response type")
 	}
 
-	var resourceResponse resourceResponseSent
+	var resourceResponse ResourceResponse
 	err = json.Unmarshal(responseBytes, &resourceResponse)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal resource response")
 	}
 
-	if resourceResponse.Error != nil {
-		return nil, resourceResponse.Error
-	}
-
-	return resourceResponse.Response, nil
+	return &resourceResponse, nil
 }
 
 // Ping sends a ping request to the server to check connectivity


### PR DESCRIPTION
## Issue
https://github.com/metoro-io/mcp-golang/issues/67

## Explanation of bug
The [`Client`](https://github.com/metoro-io/mcp-golang/blob/1fa18e024ab608dc19dafca3614e3b42657f0326/client.go#L13-L18)'s current [`ReadResource()`](https://github.com/metoro-io/mcp-golang/blob/1fa18e024ab608dc19dafca3614e3b42657f0326/client.go#L219-L249) method does not correctly parse the response from the [Protocol's request](https://github.com/metoro-io/mcp-golang/blob/1fa18e024ab608dc19dafca3614e3b42657f0326/client.go#L228-L231) to the [`Server`](https://github.com/metoro-io/mcp-golang/blob/1fa18e024ab608dc19dafca3614e3b42657f0326/server.go#L102-L113). 

That response, returned by the [`Server`](https://github.com/metoro-io/mcp-golang/blob/1fa18e024ab608dc19dafca3614e3b42657f0326/server.go#L102-L113), is ultimately [enforced to be of type *ResourceResponse](https://github.com/metoro-io/mcp-golang/blob/1fa18e024ab608dc19dafca3614e3b42657f0326/server.go#L271) when the [resource is registered](https://github.com/metoro-io/mcp-golang/blob/1fa18e024ab608dc19dafca3614e3b42657f0326/server.go#L213-L226) at server startup. This type differs from [what the `Client` is currently written to expect](https://github.com/metoro-io/mcp-golang/blob/1fa18e024ab608dc19dafca3614e3b42657f0326/client.go#L238).

## Solution
Updated the `Client`'s `ReadResponse()` method to expect type `*ResourceResponse`.

I can now set up the server, locally, with:
```go
err = server.RegisterResource(
	"example_resource.txt",
	"example",
	"Description for example resource",
	"text/plain",
	func() (*mcp.ResourceResponse, error) {
		content, err := os.ReadFile("internal/mcpserver/resources/example_resource.txt")
		if err != nil {
			return nil, fmt.Errorf("failed to read example resource: %w", err)
		}

		embeddedResource := mcp.NewTextEmbeddedResource("example_resource.txt", string(content), "text/plain")
		
		return mcp.NewResourceResponse(embeddedResource), nil
	},
)
```

And I can run the client, locally:
```go
clientTransport := http.NewHTTPClientTransport("/mcp")
clientTransport.WithBaseURL("http://localhost:8080")
...
if _, err := client.Initialize(context.Background()); err != nil {
	log.Fatalf("failed to initialize client: %v", err)
}
...
exampleResponse, err := client.ReadResource(context.Background(), "example_resource.txt")
if err != nil {
	log.Fatalf("failed to read example resource: %v", err)
}

good := exampleResponse != nil && len(exampleResponse.Contents) > 0 && exampleResponse.Contents[0] != nil && exampleResponse.Contents[0].TextResourceContents != nil
if !good {
	log.Fatalf("invalid resource response received: %+v", exampleResponse)
}

log.Printf("example resource response: %s", exampleResponse.Contents[0].TextResourceContents.Text)
```

Running the client outputs:
```
example resource response: <contents-of-internal/mcpserver/resources/example_resource.txt>
```