### PR TITLE
Fix/support to connect claude mcp filesystem

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ type Client struct {
 	protocol     *protocol.Protocol
 	capabilities *ServerCapabilities
 	initialized  bool
+	info         *ClientInfo
 }
 
 // NewClient creates a new MCP client with the specified transport
@@ -22,6 +23,20 @@ func NewClient(transport transport.Transport) *Client {
 	return &Client{
 		transport: transport,
 		protocol:  protocol.NewProtocol(nil),
+	}
+}
+
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// NewClientWithInfo create a new client with info. This is required by anthorpic mcp tools
+func NewClientWithInfo(transport transport.Transport, info *ClientInfo) *Client {
+	return &Client{
+		transport: transport,
+		protocol:  protocol.NewProtocol(nil),
+		info:      info,
 	}
 }
 
@@ -37,7 +52,11 @@ func (c *Client) Initialize(ctx context.Context) (*InitializeResponse, error) {
 	}
 
 	// Make initialize request to server
-	response, err := c.protocol.Request(ctx, "initialize", map[string]interface{}{}, nil)
+	response, err := c.protocol.Request(ctx, "initialize", map[string]interface{}{
+		"protocolVersion": "1.0",
+		"capabilities":    map[string]interface{}{},
+		"clientInfo":      c.info,
+	}, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize")
 	}

--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ type Client struct {
 	protocol     *protocol.Protocol
 	capabilities *ServerCapabilities
 	initialized  bool
-	info         *ClientInfo
+	info         ClientInfo
 }
 
 // NewClient creates a new MCP client with the specified transport
@@ -32,7 +32,7 @@ type ClientInfo struct {
 }
 
 // NewClientWithInfo create a new client with info. This is required by anthorpic mcp tools
-func NewClientWithInfo(transport transport.Transport, info *ClientInfo) *Client {
+func NewClientWithInfo(transport transport.Transport, info ClientInfo) *Client {
 	return &Client{
 		transport: transport,
 		protocol:  protocol.NewProtocol(nil),


### PR DESCRIPTION
While connecting to [mcp filesystem server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) we are getting the following error
```json
failed to initialize: RPC error -32603: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "params",
      "protocolVersion"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "undefined",
    "path": [
      "params",
      "capabilities"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "undefined",
    "path": [
      "params",
      "clientInfo"
    ],
    "message": "Required"
  }
]
```

Couldn't find much info around the documentation nor code. Just by adding `protocolVersion`, `capabilities`, `clientInfo` the issues seems to be going away. Adding client info seems to be on the right path as in documentation it mentions to share the same. But not sure on `protocolVersion` or `capabilities`.

I am open to changes. With these changes I am able to connect to MCP Fileserver