### PR TITLE
Fixed HTTPTransport - avoid overriding baseTransport fields

### DIFF
--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -15,12 +15,7 @@ type HTTPTransport struct {
 	*baseTransport
 	server         *http.Server
 	endpoint       string
-	messageHandler func(ctx context.Context, message *transport.BaseJsonRpcMessage)
-	errorHandler   func(error)
-	closeHandler   func()
-	mu             sync.RWMutex
 	addr           string
-	responseMap    map[int64]chan *transport.BaseJsonRpcMessage
 }
 
 // NewHTTPTransport creates a new HTTP transport that listens on the specified endpoint
@@ -29,7 +24,6 @@ func NewHTTPTransport(endpoint string) *HTTPTransport {
 		baseTransport: newBaseTransport(),
 		endpoint:      endpoint,
 		addr:          ":8080", // Default port
-		responseMap:   make(map[int64]chan *transport.BaseJsonRpcMessage),
 	}
 }
 


### PR DESCRIPTION
http_example client was hanging with http_example server
but it worked well with gin_example server.

HTTPTransport is composition of baseTransport repeating fields creates conflicting behaviour at runtime during baseTransport.handleMessage. After fix http_example client and server worked as expected.
