### PR TITLE
FIX: Correctly parse response in Client's ReadResource

### DIFF
--- a/client.go
+++ b/client.go
@@ -254,17 +254,13 @@ func (c *Client) ReadResource(ctx context.Context, uri string) (*ResourceRespons
 		return nil, errors.New("invalid response type")
 	}
 
-	var resourceResponse resourceResponseSent
+	var resourceResponse ResourceResponse
 	err = json.Unmarshal(responseBytes, &resourceResponse)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal resource response")
 	}
 
-	if resourceResponse.Error != nil {
-		return nil, resourceResponse.Error
-	}
-
-	return resourceResponse.Response, nil
+	return &resourceResponse, nil
 }
 
 // Ping sends a ping request to the server to check connectivity

--- a/content_api.go
+++ b/content_api.go
@@ -95,6 +95,29 @@ func (c EmbeddedResource) MarshalJSON() ([]byte, error) {
 	}
 }
 
+// Custom JSON unmarshaling for EmbeddedResource
+func (c *EmbeddedResource) UnmarshalJSON(data []byte) error {
+	// First try to unmarshal as TextResourceContents
+	var textResource TextResourceContents
+	err := json.Unmarshal(data, &textResource)
+	if err == nil && textResource.Text != "" {
+		c.EmbeddedResourceType = embeddedResourceTypeText
+		c.TextResourceContents = &textResource
+		return nil
+	}
+
+	// Then try to unmarshal as BlobResourceContents
+	var blobResource BlobResourceContents
+	err = json.Unmarshal(data, &blobResource)
+	if err == nil && blobResource.Blob != "" {
+		c.EmbeddedResourceType = embeddedResourceTypeBlob
+		c.BlobResourceContents = &blobResource
+		return nil
+	}
+
+	return fmt.Errorf("failed to unmarshal embedded resource: %v", err)
+}
+
 type ContentType string
 
 const (


### PR DESCRIPTION
This commit fixes issue metoro-io#67 where the Client's ReadResource method was incorrectly attempting to parse server responses. The bug occurred because the response type returned by the server (ResourceResponse) differed from what the client expected (resourceResponseSent).