### PR TITLE
feat: Add WithServerInstructions() constructor.

### DIFF
--- a/examples/http_example/server/main.go
+++ b/examples/http_example/server/main.go
@@ -18,7 +18,12 @@ func main() {
 	transport := http.NewHTTPTransport("/mcp").WithAddr(":8081")
 
 	// Create a new server with the transport
-	server := mcp_golang.NewServer(transport, mcp_golang.WithName("mcp-golang-stateless-http-example"), mcp_golang.WithVersion("0.0.1"))
+	server := mcp_golang.NewServer(
+		transport,
+		mcp_golang.WithName("mcp-golang-stateless-http-example"),
+		mcp_golang.WithInstructions("A simple example of a stateless HTTP server using mcp-golang"),
+		mcp_golang.WithVersion("0.0.1"),
+	)
 
 	// Register a simple tool
 	err := server.RegisterTool("time", "Returns the current time in the specified format", func(args TimeArgs) (*mcp_golang.ToolResponse, error) {

--- a/server.go
+++ b/server.go
@@ -155,6 +155,13 @@ func WithName(name string) ServerOptions {
 	}
 }
 
+func WithInstructions(instructions string) ServerOptions {
+	return func(s *Server) {
+		instructionsCopy := instructions
+		s.serverInstructions = &instructionsCopy
+	}
+}
+
 func WithVersion(version string) ServerOptions {
 	return func(s *Server) {
 		s.serverVersion = version


### PR DESCRIPTION
As it says on the tin. Exposing this constructor to test sending a global prompt to LLM clients.