### PR TITLE
feat: expose jsonschema.Schema instead of interface{}

### DIFF
--- a/tool_response_types.go
+++ b/tool_response_types.go
@@ -3,6 +3,8 @@ package mcp_golang
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/invopop/jsonschema"
 )
 
 // Capabilities that a server may support. Known capabilities are defined here, in
@@ -151,7 +153,7 @@ type ToolRetType struct {
 	Description *string `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// A JSON Schema object defining the expected parameters for the tool.
-	InputSchema interface{} `json:"inputSchema" yaml:"inputSchema" mapstructure:"inputSchema"`
+	InputSchema *jsonschema.Schema `json:"inputSchema" yaml:"inputSchema" mapstructure:"inputSchema"`
 
 	// The name of the tool.
 	Name string `json:"name" yaml:"name" mapstructure:"name"`


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Changes the `InputSchema` field type in `ToolRetType` struct from `interface{}` to a strongly-typed `*jsonschema.Schema` to improve integration with external systems like Ollama.

- Modified `tool_response_types.go` to use a concrete `*jsonschema.Schema` type instead of the generic `interface{}` for the `InputSchema` field.
- Added an import for the `github.com/invopop/jsonschema` package to support the type change.
- This change simplifies data conversion when integrating with external systems that have different tool representations.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

when trying to integrate with ollama i needed to do quite a lot of data conversion (ollama representation of a tool is very different from what we use here). i found it easier to make this data conversion if i deal directly with a jsonschema.schema instead of an interface{}.

on my tests here everything is still working with this change. if there is a better way of reading a jsonschema.schema from the tool.inputschema please let me know.