### PR TITLE
fix: fix nil pointer dereference error in error handler

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -344,7 +344,7 @@ func (p *Protocol) handleCancelledNotification(notification *transport.BaseJSONR
 }
 
 func (p *Protocol) handleResponse(response *transport.BaseJSONRPCResponse, errResp *transport.BaseJSONRPCError) {
-	var id = response.Id
+	var id transport.RequestId
 	var result interface{}
 	var err error
 
@@ -354,6 +354,7 @@ func (p *Protocol) handleResponse(response *transport.BaseJSONRPCResponse, errRe
 	} else {
 		// Parse the response
 		result = response.Result
+		id = response.Id
 	}
 
 	p.mu.RLock()


### PR DESCRIPTION
PR fixes the nil pointer dereference error in error response handler. The snippet below reproduces the issue:

```golang
package main

import (
	"context"
	"log"
	"os/exec"

	mcp "github.com/metoro-io/mcp-golang"
	"github.com/metoro-io/mcp-golang/transport/stdio"
)

func main() {
	cmd := exec.Command("npx", "-y", "@executeautomation/playwright-mcp-server")
	stdin, err := cmd.StdinPipe()
	if err != nil {
		log.Fatalf("Failed to get stdin pipe: %v", err)
	}
	stdout, err := cmd.StdoutPipe()
	if err != nil {
		log.Fatalf("Failed to get stdout pipe: %v", err)
	}

	if err := cmd.Start(); err != nil {
		log.Fatalf("Failed to start server: %v", err)
	}
	defer cmd.Process.Kill()

	transport := stdio.NewStdioServerTransportWithIO(stdout, stdin)
	client := mcp.NewClient(transport)

	if _, err := client.Initialize(context.Background()); err != nil {
		log.Fatalf("Failed to initialize: %v", err)
	}

	// nil value for cursor causes the error
	res, err := client.ListTools(context.Background(), nil)
	if err != nil {
		log.Fatalf("Failed to list res: %v", err)
	}
	for _, tool := range res.Tools {
		log.Printf("Tool: %s", tool.Name)
	}
}
```