### PR TITLE
FIX: fixed panic in createPromptSchemaFromHandler when handler has a context param

### DIFF
--- a/server.go
+++ b/server.go
@@ -427,7 +427,13 @@ func createWrappedPromptHandler(userHandler any) func(context.Context, baseGetPr
 func createPromptSchemaFromHandler(handler any) *PromptSchema {
 	handlerValue := reflect.ValueOf(handler)
 	handlerType := handlerValue.Type()
-	argumentType := handlerType.In(0)
+
+	var argumentType reflect.Type
+	if handlerType.NumIn() == 2 {
+		argumentType = handlerType.In(1)
+	} else if handlerType.NumIn() == 1 {
+		argumentType = handlerType.In(0)
+	}
 
 	promptSchema := PromptSchema{
 		Arguments: make([]PromptSchemaArgument, argumentType.NumField()),


### PR DESCRIPTION
See other methods that handle the case when  `context.Context` is the first param.
Looks like non of the samples use 2 params so the `panic` was never caught on `RegisterPrompt`

This fix is tested in my prod deployment.