### PR TITLE
Revert "HTTPClientTransport WithClient"

### DIFF
--- a/transport/http/http_client.go
+++ b/transport/http/http_client.go
@@ -45,12 +45,6 @@ func (t *HTTPClientTransport) WithHeader(key, value string) *HTTPClientTransport
 	return t
 }
 
-// WithClient sets the HTTP client to use for requests
-func (t *HTTPClientTransport) WithClient(client *http.Client) *HTTPClientTransport {
-	t.client = client
-	return t
-}
-
 // Start implements Transport.Start
 func (t *HTTPClientTransport) Start(ctx context.Context) error {
 	// Does nothing in the stateless http client transport


### PR DESCRIPTION
Reverts metoro-io/mcp-golang#113 in order to merge https://github.com/metoro-io/mcp-golang/pull/111 which allows for custom http client to be used. 