### PR TITLE
Fix:  update the "RegisterTool" method in server.go

### DIFF
--- a/server.go
+++ b/server.go
@@ -209,6 +209,23 @@ func (s *Server) RegisterTool(name string, description string, handler any) erro
 	return s.sendToolListChangedNotification()
 }
 
+func (s *Server) RegisterToolWithInputSchema(name string, description string, handler any, inputSchema *jsonschema.Schema) error {
+	err := validateToolHandler(handler)
+	if err != nil {
+		return err
+	}
+	//inputSchema := createJsonSchemaFromHandler(handler)
+
+	s.tools.Store(name, &tool{
+		Name:            name,
+		Description:     description,
+		Handler:         createWrappedToolHandler(handler),
+		ToolInputSchema: inputSchema,
+	})
+
+	return s.sendToolListChangedNotification()
+}
+
 func (s *Server) sendToolListChangedNotification() error {
 	if !s.isRunning {
 		return nil


### PR DESCRIPTION
When we were creating a new server registration tool, we used the "RegisterTool" method, but the "handler any" in it and the "createJsonSchemaFromHandler" method left us quite confused. We think the inputSchema can be passed in directly without the need for conversion.