### PR TITLE
Fix concurrent write under high load

### DIFF
--- a/transport/http/common.go
+++ b/transport/http/common.go
@@ -145,7 +145,9 @@ func (t *baseTransport) handleMessage(ctx context.Context, body []byte) (*transp
 
 	// Block until the response is received
 	responseToUse := <-t.responseMap[key]
+	t.mu.Lock()
 	delete(t.responseMap, key)
+	t.mu.Unlock()
 	if prevId != nil {
 		responseToUse.JsonRpcResponse.Id = *prevId
 	}


### PR DESCRIPTION
This delete was not properly guarded by a mutex. Under high load it would be a concurrent write and a panic