### PR TITLE
Fix: Add missing notifications/initialized message after client initialization

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,6 +74,14 @@ func (c *Client) Initialize(ctx context.Context) (*InitializeResponse, error) {
 
 	c.capabilities = &initResult.Capabilities
 	c.initialized = true
+
+	// Send notifications/initialized message as required by MCP protocol
+	// This notifies the server that the client has completed initialization
+	// and is ready to receive requests. Python MCP servers require this.
+	if err := c.protocol.Notification("notifications/initialized", map[string]interface{}{}); err != nil {
+		return nil, errors.Wrap(err, "failed to send initialized notification")
+	}
+
 	return &initResult, nil
 }
 


### PR DESCRIPTION
## Problem

Python MCP servers (like mcp-server-fetch) require a `notifications/initialized` message after the `initialize` response to complete the initialization sequence according to the MCP protocol specification. Without this notification, Python servers reject subsequent requests with "Invalid request parameters" errors.

## Root Cause

The Go MCP client was missing the required `notifications/initialized` notification that signals the client has completed initialization and is ready to receive requests. This is enforced by Python MCP servers but not by TypeScript servers, causing compatibility issues.

## Solution

Added the missing notification in the `Initialize` method after successful initialization:

```go
// Send notifications/initialized message as required by MCP protocol
// This notifies the server that the client has completed initialization
// and is ready to receive requests. Python MCP servers require this.
if err := c.protocol.Notification("notifications/initialized", map[string]interface{}{}); err != nil {
    return nil, errors.Wrap(err, "failed to send initialized notification")
}
```

## Testing

- ✅ Verified compatibility with Python MCP servers (mcp-server-fetch now works)
- ✅ Confirmed no breaking changes to TypeScript MCP servers (filesystem server still works)
- ✅ Follows MCP protocol specification for proper initialization sequence

## Impact

This change ensures the Go MCP client properly follows the MCP protocol initialization sequence, making it compatible with both TypeScript and Python MCP server implementations without breaking existing functionality.

Fixes compatibility with Python MCP servers including:
- mcp-server-fetch
- mcp-server-git  
- mcp-server-time
- And other Python-based MCP servers

## Checklist

- [x] Tested with Python MCP servers
- [x] Tested with TypeScript MCP servers  
- [x] No breaking changes
- [x] Follows MCP protocol specification