### PR TITLE
Cursor can't connect to servers, fails on list/prompts message

### DIFF
--- a/server.go
+++ b/server.go
@@ -735,9 +735,13 @@ func (s *Server) handleListPrompts(ctx context.Context, request *transport.BaseJ
 		Cursor *string `json:"cursor"`
 	}
 	var params promptRequestParams
-	err := json.Unmarshal(request.Params, &params)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal arguments")
+	if request.Params == nil {
+		params = promptRequestParams{}
+	} else {
+		err := json.Unmarshal(request.Params, &params)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal arguments")
+		}
 	}
 
 	// Order by name for pagination


### PR DESCRIPTION
The `handleListPrompts` method doesn't consider that Params can be null. The Cursor application sends null/empty value for Params on that method. 

The other lists do this:

* [handleListTools](https://github.com/metoro-io/mcp-golang/blob/main/server.go#L621-L628)
* [handleListResources](https://github.com/metoro-io/mcp-golang/blob/main/server.go#L802-L809)
* [handleListResourceTemplates](https://github.com/metoro-io/mcp-golang/blob/main/server.go#L874-L881)

My PR is following the same pattern.

Also, https://github.com/metoro-io/mcp-golang/pull/117 has a similar fix and fixes other things. I've made this PR in case the maintainers would like a more focused fix to bring in. Please close this if/when https://github.com/metoro-io/mcp-golang/pull/117 is merged.